### PR TITLE
avoid warning message adding weight to aes

### DIFF
--- a/stat_ecdf_weighted.R
+++ b/stat_ecdf_weighted.R
@@ -89,5 +89,7 @@ StatEcdf <- ggproto("StatEcdf", Stat,
                     
                     default_aes = aes(y = stat(y)),
                     
-                    required_aes = c("x")
+                    required_aes = c("x"),
+
+                    dropped_aes = c("weight")
 )


### PR DESCRIPTION
avoid message at adding weight argument to aes().

The following aesthetics were dropped during statistical transformation: weight.
ℹ This can happen when ggplot fails to infer the correct grouping structure in the
  data.
ℹ Did you forget to specify a `group` aesthetic or to convert a numerical variable
  into a factor? 